### PR TITLE
Remove duplicate numpy import in datamsg test

### DIFF
--- a/swat/tests/cas/test_datamsg.py
+++ b/swat/tests/cas/test_datamsg.py
@@ -26,7 +26,6 @@ import copy
 import datetime
 import numpy as np
 import pandas as pd
-import numpy as np
 import os
 import six
 import swat


### PR DESCRIPTION
The goal of this PR is to remove the duplicate `import numpy as np` declaration in `swat/tests/cas/test_datamsg.py`.