### PR TITLE
Simplify isinstance logic to use tuples

### DIFF
--- a/swat/cas/connection.py
+++ b/swat/cas/connection.py
@@ -761,7 +761,7 @@ class CAS(object):
                     else:
                         raise SWATError('%s is not a valid boolean value' % value)
                 elif typ == 'string':
-                    if isinstance(value, binary_types) or isinstance(value, text_types):
+                    if isinstance(value, (binary_types, text_types)):
                         errorcheck(self._sw_connection.setStringOption(name, a2n(value)),
                                    self._sw_connection)
                     else:

--- a/swat/cas/datamsghandlers.py
+++ b/swat/cas/datamsghandlers.py
@@ -330,7 +330,7 @@ class CASDataMsgHandler(object):
             if vrtype == 'CHAR' or vtype in ['VARCHAR', 'CHAR', 'BINARY', 'VARBINARY']:
                 if vtype in ['BINARY', 'VARBINARY'] and \
                         hasattr(self._sw_databuffer, 'setBinaryFromBase64'):
-                    if isinstance(value, binary_types) or isinstance(value, text_types):
+                    if isinstance(value, (binary_types, text_types)):
                         errorcheck(self._sw_databuffer.setBinaryFromBase64(row, offset,
                                         a2n(base64.b64encode(a2b(transformer(value))))),
                                    self._sw_databuffer)

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -226,13 +226,13 @@ def _get_table_selection(table, args):
             columns = None
             lowcolumns = None
             colstart, colstep, colend = cols.start, cols.step, cols.stop
-            if isinstance(colstart, text_types) or isinstance(colstart, binary_types):
+            if isinstance(colstart, (text_types, binary_types)):
                 if not columns:
                     columns = list(table.columns)
                     lowcolumns = [x.lower() for x in columns]
                 colstart = lowcolumns.index(colstart.lower())
                 use_names = True
-            if isinstance(colend, text_types) or isinstance(colend, binary_types):
+            if isinstance(colend, (text_types, binary_types)):
                 if not columns:
                     columns = list(table.columns)
                     lowcolumns = [x.lower() for x in columns]
@@ -260,7 +260,7 @@ def _get_table_selection(table, args):
                 outtype = 'column'
 
         # tbl.x[0, 'a']
-        elif isinstance(cols, text_types) or isinstance(cols, binary_types):
+        elif isinstance(cols, (text_types, binary_types)):
             cols = [cols]
             if outtype == 'row':
                 outtype = 'scalar'
@@ -1103,7 +1103,7 @@ class CASTable(ParamManager, ActionParamManager):
         for item in items:
             if not item:
                 continue
-            if isinstance(item, text_types) or isinstance(item, binary_types):
+            if isinstance(item, (text_types, binary_types)):
                 orderby.append(dict(name=item))
             elif isinstance(item, dict):
                 orderby.append(item)
@@ -1111,8 +1111,7 @@ class CASTable(ParamManager, ActionParamManager):
                 for subitem in item:
                     if not subitem:
                         continue
-                    if isinstance(subitem, text_types) or \
-                            isinstance(subitem, binary_types):
+                    if isinstance(subitem, (text_types, binary_types)):
                         orderby.append(dict(name=subitem))
                     else:
                         orderby.append(subitem)
@@ -2662,7 +2661,7 @@ class CASTable(ParamManager, ActionParamManager):
 
         if casout is None:
             casout = {'name': _gen_table_name()}
-        elif isinstance(casout, text_types) or isinstance(casout, binary_types):
+        elif isinstance(casout, (text_types, binary_types)):
             casout = {'name': casout}
 
         outdata = casout['name']
@@ -4282,9 +4281,8 @@ class CASTable(ParamManager, ActionParamManager):
             regex = True
 
         # to_replace is a string
-        if isinstance(to_replace, char_types) or isinstance(to_replace, regex_type):
-            if isinstance(value, char_types) or isinstance(value, num_types) or \
-                    isinstance(value, regex_type):
+        if isinstance(to_replace, (char_types, regex_type)):
+            if isinstance(value, (char_types, num_types, regex_type)):
                 repl.update(scalar_to_repl(to_replace, value))
             elif isinstance(value, dict):
                 repl.update(dict_to_repl(to_replace, value))
@@ -4294,8 +4292,7 @@ class CASTable(ParamManager, ActionParamManager):
 
         # to_replace is numeric
         elif isinstance(to_replace, num_types):
-            if isinstance(value, num_types) or isinstance(value, char_types) or \
-                    isinstance(value, regex_type):
+            if isinstance(value, (num_types, char_types, regex_type)):
                 repl.update(scalar_to_repl(to_replace, value))
             elif isinstance(value, dict):
                 repl.update(dict_to_repl(to_replace, value))
@@ -4304,9 +4301,9 @@ class CASTable(ParamManager, ActionParamManager):
                                 % type(value))
 
         # to_replace is a list
-        elif isinstance(to_replace, items_types) or isinstance(to_replace, pd.Series):
+        elif isinstance(to_replace, (items_types, pd.Series)):
             to_replace = list(to_replace)
-            if isinstance(value, items_types) or isinstance(value, pd.Series):
+            if isinstance(value, (items_types, pd.Series)):
                 repl.update(list_to_repl(to_replace, list(value)))
             else:
                 repl.update(list_to_repl(to_replace, [value] * len(to_replace)))
@@ -5636,7 +5633,7 @@ class CASTable(ParamManager, ActionParamManager):
             computedvarsprogram.append(cpgm)
             computedvarsprogram.append('%s = %s; ' % (key, cexpr))
 
-        elif isinstance(value, text_types) or isinstance(value, binary_types):
+        elif isinstance(value, (text_types, binary_types)):
             computedvarsprogram.append('%s = "%s"; ' % (key, _escape_string(value)))
 
         else:
@@ -7571,8 +7568,7 @@ class CASColumn(CASTable):
                 for item in value:
                     if eval_values and isinstance(item, (CASColumn, pd.Series)):
                         for subitem in item.unique().tolist():
-                            if isinstance(subitem, text_types) or \
-                                    isinstance(subitem, binary_types):
+                            if isinstance(subitem, (text_types, binary_types)):
                                 items.append('"%s"' % _escape_string(subitem))
                             else:
                                 items.append(str(subitem))
@@ -7581,8 +7577,7 @@ class CASColumn(CASTable):
                         computedvars.append(acomputedvars)
                         computedvarsprogram.append(acomputedvarsprogram)
                         items.append(aexpr)
-                    elif isinstance(item, text_types) or \
-                            isinstance(item, binary_types):
+                    elif isinstance(item, (text_types, binary_types)):
                         items.append('"%s"' % _escape_string(item))
                     else:
                         items.append(str(item))
@@ -7634,7 +7629,7 @@ class CASColumn(CASTable):
             right, rcomputedvars, rcomputedvarsprogram = right._to_expression()
             computedvars.append(rcomputedvars)
             computedvarsprogram.append(rcomputedvarsprogram)
-        elif isinstance(right, text_types) or isinstance(right, binary_types):
+        elif isinstance(right, (text_types, binary_types)):
             right = repr(right)
 
         opname = OPERATOR_NAMES.get(operator, operator)
@@ -8341,7 +8336,7 @@ class CASColumn(CASTable):
         if sort:
             if sort is True:
                 sortby = [dict(name=self.name)]
-            elif isinstance(sort, text_types) or isinstance(sort, binary_types):
+            elif isinstance(sort, (text_types, binary_types)):
                 sortby = [dict(name=self.name, order=sort)]
             else:
                 sortby = sort
@@ -8475,8 +8470,7 @@ class CASTableGroupBy(object):
             if pd.isnull(value):
                 grptbl.append_where('%s = .' % _nlit(key))
             else:
-                if isinstance(value, text_types) or \
-                        isinstance(value, binary_types):
+                if isinstance(value, (text_types, binary_types)):
                     value = '"%s"' % _escape_string(value)
                 else:
                     value = str(value)

--- a/swat/cas/transformers.py
+++ b/swat/cas/transformers.py
@@ -476,7 +476,7 @@ def py2cas(soptions, _sw_error, **kwargs):
            The next position in the list to set
 
         '''
-        if isinstance(key, binary_types) or isinstance(key, text_types):
+        if isinstance(key, (binary_types, text_types)):
             key = keywordify(a2n(key, 'utf-8'))
 
         if item is True or item is False:

--- a/swat/dataframe.py
+++ b/swat/dataframe.py
@@ -392,7 +392,7 @@ class SASDataFrame(pd.DataFrame):
                 return float64(obj)
             if isinstance(obj, int64_types):
                 return int64(obj)
-            if isinstance(obj, int32_types) or isinstance(obj, bool_types):
+            if isinstance(obj, (int32_types, bool_types)):
                 return int32(obj)
             if isinstance(obj, CASTable):
                 return str(obj)

--- a/swat/tests/cas/test_imstat.py
+++ b/swat/tests/cas/test_imstat.py
@@ -224,7 +224,7 @@ class TestIMStat(tm.TestCase):
 
         for rowIdx, rowVal in enumerate(actual):                
             for colIdx, colVal in enumerate(rowVal):
-                if isinstance(colVal, str) or isinstance(colVal, unicode):
+                if isinstance(colVal, (str, unicode)):
                     self.assertEqual(colVal, expected[rowIdx][colIdx])
                 else:
                     self.assertAlmostEqual(colVal, expected[rowIdx][colIdx], places=2)                                 

--- a/swat/utils/args.py
+++ b/swat/utils/args.py
@@ -84,7 +84,7 @@ def dict2kwargs(dct, fmt='dict(%s)', nestfmt='dict(%s)', ignore=None):
         elif isinstance(value, items_types):
             sublist = []
             for item in value:
-                if isinstance(item, dict) or isinstance(item, items_types):
+                if isinstance(item, (dict, items_types)):
                     sublist.append(dict2kwargs(item))
                 else:
                     sublist.append(repr(item))


### PR DESCRIPTION
The goal of this PR is to simplify `isinstance` logic throughout the project.  Opposed to conducting numerous if checks like:

`if isinstance(value, str) or isinstance(value, int):`

Modify occurrences throughout the project to use tuples in multi-check cases:

`if isinstance(value, (str, int)):`