### PR TITLE
Modify table describe to use list extending for concat

### DIFF
--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -3089,7 +3089,7 @@ class CASTable(ParamManager, ActionParamManager):
             percentiles = [25, 50, 75]
 
         if 50 not in percentiles:
-            percentiles = percentiles + [50]
+            percentiles.append(50)
 
         percentiles = _get_unique(sorted(percentiles))
 


### PR DESCRIPTION
The goal of this PR is to conform to best practices for speed by using `extend()` versus list reassignment while adding the additional list entry.