### PR TITLE
Modify equality checking involving multiple variables

### DIFF
--- a/swat/cas/connection.py
+++ b/swat/cas/connection.py
@@ -754,7 +754,7 @@ class CAS(object):
                              self._sw_connection)
             try:
                 if typ == 'boolean':
-                    if value is True or value == 1 or value is False or value == 0:
+                    if value in [True, False, 1, 0]:
                         errorcheck(self._sw_connection.setBooleanOption(name,
                                                                         value and 1 or 0),
                                    self._sw_connection)

--- a/swat/dataframe.py
+++ b/swat/dataframe.py
@@ -901,7 +901,7 @@ class SASDataFrame(pd.DataFrame):
                 bylabel = attrs.get(bykey + 'Label')
                 sasfmt = attrs.get(bykey + 'Format')
                 sasfmtwidth = split_format(sasfmt).width
-                if bygroup_columns == 'both' or bygroup_columns == 'raw':
+                if bygroup_columns in ['both', 'raw']:
                     dframe = dframe.set_index(pd.Series(data=[byval] * len(dframe),
                                                         name=byname),
                                               append=appendlevels)
@@ -911,7 +911,7 @@ class SASDataFrame(pd.DataFrame):
                                                            width=sasfmtwidth)
                     bylevels += 1
                     appendlevels = True
-                if bygroup_columns == 'both' or bygroup_columns == 'formatted':
+                if bygroup_columns in ['both', 'formatted']:
                     if bygroup_columns == 'both':
                         byname = byname + bygroup_formatted_suffix
                     dframe = dframe.set_index(pd.Series(data=[byvalfmt] * len(dframe),
@@ -941,7 +941,7 @@ class SASDataFrame(pd.DataFrame):
                 bylabel = attrs.get(bykey + 'Label')
                 sasfmt = attrs.get(bykey + 'Format')
                 sasfmtwidth = split_format(sasfmt).width
-                if bygroup_columns == 'both' or bygroup_columns == 'raw':
+                if bygroup_columns in ['both', 'raw']:
                     if byname in allcolnames:
                         byname = byname + bygroup_collision_suffix
                     dframe[byname] = byval
@@ -950,7 +950,7 @@ class SASDataFrame(pd.DataFrame):
                                                            dtype=dtype_from_var(byval),
                                                            format=sasfmt,
                                                            width=sasfmtwidth)
-                if bygroup_columns == 'both' or bygroup_columns == 'formatted':
+                if bygroup_columns in ['both', 'formatted']:
                     if bygroup_columns == 'both':
                         byname = byname + bygroup_formatted_suffix
                     elif bygroup_columns == 'formatted' and byname in allcolnames:


### PR DESCRIPTION
The goal of this PR is to simplify multiple variable value checking where the same variable is referenced multiple times for `if variable == value1 or if variable == value2` to `if variable in [value1, value2]`