### PR TITLE
CASTable docstring edits

### DIFF
--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -2783,7 +2783,7 @@ class CASTable(ParamManager, ActionParamManager):
         columns : list-of-strings, optional
             A subset of columns to return.
         bygroup_as_index : boolean
-            When By groups are specified, if bygroup_as_index is True, By groups are converted to an index
+            When by_group_index is True, By groups are converted to an index if they exist
 
         Notes
         -----
@@ -2812,8 +2812,8 @@ class CASTable(ParamManager, ActionParamManager):
         columns : list-of-strings, optional
             A subset of columns to return.
         bygroup_as_index : boolean
-            When By groups are specified, if bygroup_as_index is True, By groups are converted to an index
-
+            When by_group_index is True, By groups are converted to an index if they exist
+            
         Notes
         -----
         Since CAS tables can be distributed across a grid of computers,
@@ -2845,8 +2845,8 @@ class CASTable(ParamManager, ActionParamManager):
         columns : list-of-strings, optional
             A subset of columns to return.
         bygroup_as_index : boolean
-            When By groups are specified, if bygroup_as_index is True, By groups are converted to an index
-
+            When by_group_index is True, By groups are converted to an index if they exist
+            
         Notes
         -----
         Since CAS tables can be distributed across a grid of computers,
@@ -3424,7 +3424,7 @@ class CASTable(ParamManager, ActionParamManager):
         casout : dict, optional
             The CAS output table definition
         inplace : bool, optional
-            If True, the output table is overwritten
+            If True, the output table is overwritten if it exists
             NOTE: If `prefix` or `suffix` are used, this option is only
                   used to determine the table's base name.
         prefix : string, optional
@@ -3505,7 +3505,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def all(self, axis=None, bool_only=None, skipna=True, level=None, **kwargs):
         '''
-        Return True for each column with only True elements
+        Return True for each column with only elements that evaluate to True
 
         Parameters
         ----------
@@ -7796,7 +7796,7 @@ class CharacterColumnMethods(object):
 
     def contains(self, pat, case=True, flags=0, na=np.nan, regex=True):
         '''
-        Indicates wheter the value contains the specified pattern.
+        Indicates whether the value contains the specified pattern
 
         Parameters
         ----------
@@ -7863,7 +7863,7 @@ class CharacterColumnMethods(object):
 
     def endswith(self, pat, case=True, flags=0, na=np.nan, regex=True):
         '''
-        Indicates whether the table column ends with the given pattern.
+        Indicates whether the table column ends with the given pattern
 
         Parameters
         ----------
@@ -8174,7 +8174,7 @@ class CharacterColumnMethods(object):
 
     def startswith(self, pat, case=True, flags=0, na=np.nan, regex=True):
         '''
-        Indicates wheter the table column start with the given pattern.
+        Indicates whether the table column start with the given pattern
 
         Parameters
         ----------
@@ -8251,7 +8251,7 @@ class CharacterColumnMethods(object):
 
     def isalnum(self):
         '''
-        Indicates whether the value contains only alphanumeric characters.
+        Indicates whether the value contains only alphanumeric characters
 
         See Also
         --------
@@ -8266,7 +8266,7 @@ class CharacterColumnMethods(object):
 
     def isalpha(self):
         '''
-        Indicates whether the value contains only alpha characters.
+        Indicates whether the value contains only alpha characters
 
         See Also
         --------
@@ -8281,7 +8281,7 @@ class CharacterColumnMethods(object):
 
     def isdigit(self):
         '''
-        Indicates wheter the value contains only digits.
+        Indicates whether the value contains only digits
 
         See Also
         --------
@@ -8296,7 +8296,7 @@ class CharacterColumnMethods(object):
 
     def isspace(self):
         '''
-        Indicates whether the value contains only whitespace.
+        Indicates whether the value contains only whitespace
 
         See Also
         --------
@@ -8311,7 +8311,7 @@ class CharacterColumnMethods(object):
 
     def islower(self):
         '''
-        Indicates whether the value contain only lowercase characters?
+        Indicates whether the value contain only lowercase characters
 
         See Also
         --------
@@ -8326,7 +8326,7 @@ class CharacterColumnMethods(object):
 
     def isupper(self):
         '''
-        Does the value contains only uppercase characters.
+        Indicates whether the value contains only uppercase characters
 
         See Also
         --------
@@ -8341,7 +8341,7 @@ class CharacterColumnMethods(object):
 
     def istitle(self):
         '''
-        Indicates whether the value is equivalent to the title representation.
+        Indicates whether the value is equivalent to the title representation
 
         See Also
         --------
@@ -8356,7 +8356,7 @@ class CharacterColumnMethods(object):
 
     def isnumeric(self):
         '''
-        Indicates whether the value contains a numeric representation.
+        Indicates whether the value contains a numeric representation
 
         See Also
         --------
@@ -8371,7 +8371,7 @@ class CharacterColumnMethods(object):
 
     def isdecimal(self):
         '''
-        Indicates whether the value contains a decimal representation.
+        Indicates whether the value contains a decimal representation
 
         See Also
         --------

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -126,7 +126,7 @@ def _get_unique(seq, lowercase=False):
     Parameters
     ----------
     lowercase : boolean
-        Should values be compared in a case-insensitive way?
+        If true, compare elements in a case-insensitive way
 
     Returns
     -------
@@ -301,8 +301,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
     copy : boolean, optional
         Not supported.
     indicator : boolean or string, optional
-        Should a column be created that indicates which table the
-        key came from?  If True, a column named '_merge' will be
+        If True, a column named '_merge' will be
         created with the values: 'left_only', 'right_only', or
         'both'.  If False, no column is created.  If a string is
         specified, a column is created using that name containing
@@ -2659,7 +2658,7 @@ class CASTable(ParamManager, ActionParamManager):
         exclude : list-of-strings, optional
             List of data type names to exclude from result
         inplace : boolean, optional
-            Should the table be modified in place?
+            If True, the table is modified in place
 
         Notes
         -----
@@ -2733,7 +2732,7 @@ class CASTable(ParamManager, ActionParamManager):
         Parameters
         ----------
         deep : boolean, optional
-            Should all list / dict-type objects be deep copied?
+            If True, all lists and dict-type objects are deep copied
         exclude : list-of-strings, optional
             Parameters that should be excluded (top-level only).
 
@@ -2784,7 +2783,7 @@ class CASTable(ParamManager, ActionParamManager):
         columns : list-of-strings, optional
             A subset of columns to return.
         bygroup_as_index : boolean
-            If By groups are specified, should they be converted to an index?
+            When By groups are specified, if bygroup_as_index is True, By groups are converted to an index
 
         Notes
         -----
@@ -2813,7 +2812,7 @@ class CASTable(ParamManager, ActionParamManager):
         columns : list-of-strings, optional
             A subset of columns to return.
         bygroup_as_index : boolean
-            If By groups are specified, should they be converted to an index?
+            When By groups are specified, if bygroup_as_index is True, By groups are converted to an index
 
         Notes
         -----
@@ -2846,7 +2845,7 @@ class CASTable(ParamManager, ActionParamManager):
         columns : list-of-strings, optional
             A subset of columns to return.
         bygroup_as_index : boolean
-            If By groups are specified, should they be converted to an index?
+            When By groups are specified, if bygroup_as_index is True, By groups are converted to an index
 
         Notes
         -----
@@ -3425,7 +3424,7 @@ class CASTable(ParamManager, ActionParamManager):
         casout : dict, optional
             The CAS output table definition
         inplace : bool, optional
-            Should the output table be overwritten?
+            If True, the output table is overwritten
             NOTE: If `prefix` or `suffix` are used, this option is only
                   used to determine the table's base name.
         prefix : string, optional
@@ -4332,11 +4331,11 @@ class CASTable(ParamManager, ActionParamManager):
         axis : int, optional
             Unsupported
         skipna : bool, optional
-            Should missing values be dropped?
+            If True, missing values are dropped
         level : int, optional
             Unsupported
         numeric_only : bool, optional
-            Should just the numeric variables be used?
+            If True, just the numeric variables will be used
         percentile_values : list-of-floats, optional
             The list of percentiles to compute
 
@@ -4523,8 +4522,8 @@ class CASTable(ParamManager, ActionParamManager):
         table : CASTable
             Percentile output table
         single : bool, optional
-            Is this a single quantile computation?  If so, the quantile column
-            is dropped.
+            If True, this is a single quantile computation and the quantile column
+            is dropped
 
         Returns
         -------
@@ -4992,11 +4991,11 @@ class CASTable(ParamManager, ActionParamManager):
         columns : string or list-of-strings, optional
             Names of the columns to sort by
         ascending : bool, optional
-            Should the sort order be ascending or descending?
+            If True, the sort order is ascending
         casout : bool or string or CASTable or dict, optional
             The CAS output table specification
         single : bool, optional
-            Should `n` be interpretted as a range or single value?
+            If True, `n` is interpretted as a single value
 
         Returns
         -------
@@ -5889,8 +5888,8 @@ class CASTable(ParamManager, ActionParamManager):
         subset : list-of-strings, optional
             Not supported
         inplace : boolean, optional
-            Should the table be modified in place, or should a new
-            table be created?
+            If True, the table modified in place. If False, a new
+            table is created.
 
         Returns
         -------
@@ -5938,8 +5937,8 @@ class CASTable(ParamManager, ActionParamManager):
         axis : int or string, optional
             Not supported.   The axis is always 'columns'.
         inplace : boolean, optional
-            Should the data be modified in-place, or should a new table
-            be created?
+            If True, the data is modified in place. If False, a new table
+            be created.
         limit : int, optional
             Not supported
         downcast : dict, optional
@@ -6007,7 +6006,7 @@ class CASTable(ParamManager, ActionParamManager):
             Values to use as replacements.  If a dict is specified, it takes
             the same form as a dictionary in the `to_replace=` parameter.
         inplace : boolean, optional
-            Should the table be modified in-place, or should a new table be created?
+            If True, the table is modified in-place. If False, a new table is created.
         limit : int, optional
             Not supported
         regex : boolean or same types as `to_replace`, optional
@@ -6236,7 +6235,7 @@ class CASTable(ParamManager, ActionParamManager):
         code : string or list-of-strings
             The date step code to apply
         inplace : boolean, optional
-            Should the table be modified in-place?
+            If True, the table is modified in place
         casout : dict, optional
             The output table specification
         prefix : string, optional
@@ -6485,8 +6484,7 @@ class CASTable(ParamManager, ActionParamManager):
         copy : boolean, optional
             Not supported.
         indicator : boolean or string, optional
-            Should a column be created that indicates which table the
-            key came from?  If True, a column named '_merge' will be
+            If True, a column named '_merge' will be
             created with the values: 'left_only', 'right_only', or
             'both'.  If False, no column is created.  If a string is
             specified, a column is created using that name containing
@@ -6547,7 +6545,7 @@ class CASTable(ParamManager, ActionParamManager):
         Parameters
         ----------
         grouped : bool, optional
-            Should the output DataFrame be returned as By groups?
+            If True, the output DataFrame is returned as By groups.
         sample_pct : int, optional
             Percentage of original data set to return as samples
         sample_seed : int, optional
@@ -6965,15 +6963,15 @@ class CASTable(ParamManager, ActionParamManager):
         Parameters
         ----------
         verbose : boolean, optional
-            Should the full summary be printed?
+            If True, the full summary is printed
         buf : writeable file-like object
             Where the summary is printed to.
         max_cols : int, optional
             The maximum number of columns to include in the summary.
         memory_usage : boolean, optional
-            Should the memory usage be displayed?
+            If True, the memory usage is displayed
         null_counts : boolean, optional
-            Should missing values be displayed?
+            If True, missing values will be displayed
 
         See Also
         --------
@@ -7648,9 +7646,9 @@ class CASTable(ParamManager, ActionParamManager):
         level : int, optional
             Not implemented.
         as_index : boolean, optional
-            Should the grouping variables be set as index levels?
+            If True, the grouping variables are set as index levels
         sort : boolean, optional
-            Should output be sorted by group keys?
+            If True, output will be sorted by group keys.
         squeeze : boolean, optional
             Not implemented.
 
@@ -7798,20 +7796,20 @@ class CharacterColumnMethods(object):
 
     def contains(self, pat, case=True, flags=0, na=np.nan, regex=True):
         '''
-        Does the value contain the specified pattern?
+        Indicates wheter the value contains the specified pattern.
 
         Parameters
         ----------
         pat : string or :class:`CASColumn`
             The pattern to search for.
         case : boolean, optional
-            Should pattern matching be case-sensitive?
+            If True, the pattern matching is case-sensitive.
         flags : int, optional
             Regular expression matching flags.
         na : string, optional
             Not implemented.
         regex : boolean, optional
-            Should the pattern be treated as a regular expression?
+            If True, the pattern is treated as a regular expression
 
         See Also
         --------
@@ -7865,20 +7863,20 @@ class CharacterColumnMethods(object):
 
     def endswith(self, pat, case=True, flags=0, na=np.nan, regex=True):
         '''
-        Does the table column end with the given pattern?
+        Indicates whether the table column ends with the given pattern.
 
         Parameters
         ----------
         pat : string or :class:`CASColumn`
             The string to search for.
         case : boolean, optional
-            Should the pattern matching be case-sensitive?
+            If True, the pattern matching is case-sensitive.
         flags : int, optional
             Regular expression flags.
         na : string, optional
             Not implemented.
         regex : boolean, optional
-            Should the pattern be considered a regular expression?
+            If True, the pattern is considered a regular expression.
 
         See Also
         --------
@@ -8047,7 +8045,7 @@ class CharacterColumnMethods(object):
         n : int, optional
             The maximum number of replacements.
         case : boolean, optional
-            Should the pattern matching be case-insensitive?
+            If True, the pattern matching is case-sensitive.
         flags : int, optional
             Regular expression flags.
 
@@ -8176,20 +8174,20 @@ class CharacterColumnMethods(object):
 
     def startswith(self, pat, case=True, flags=0, na=np.nan, regex=True):
         '''
-        Does the table column start with the given pattern?
+        Indicates wheter the table column start with the given pattern.
 
         Parameters
         ----------
         pat : string or :class:`CASColumn`
             The pattern to search for.
         case : boolean, optional
-            Should the matching be case-sensitive?
+            If True, the matching is case-sensitive.
         flags : int, optional
             Regular expression flags.
         na : string, optional
             Not implemented.
         regex : boolean, optional
-            Is the pattern a regular expression?
+            If True, the pattern is considered a regular expression.
 
         See Also
         --------
@@ -8253,7 +8251,7 @@ class CharacterColumnMethods(object):
 
     def isalnum(self):
         '''
-        Does the value contain only alphanumeric characters?
+        Indicates whether the value contains only alphanumeric characters.
 
         See Also
         --------
@@ -8268,7 +8266,7 @@ class CharacterColumnMethods(object):
 
     def isalpha(self):
         '''
-        Does the value contain only alpha characters?
+        Indicates whether the value contains only alpha characters.
 
         See Also
         --------
@@ -8283,7 +8281,7 @@ class CharacterColumnMethods(object):
 
     def isdigit(self):
         '''
-        Does the value contain only digits?
+        Indicates wheter the value contains only digits.
 
         See Also
         --------
@@ -8298,7 +8296,7 @@ class CharacterColumnMethods(object):
 
     def isspace(self):
         '''
-        Does the value contain only whitespace?
+        Indicates whether the value contains only whitespace.
 
         See Also
         --------
@@ -8313,7 +8311,7 @@ class CharacterColumnMethods(object):
 
     def islower(self):
         '''
-        Does the value contain only lowercase characters?
+        Indicates whether the value contain only lowercase characters?
 
         See Also
         --------
@@ -8328,7 +8326,7 @@ class CharacterColumnMethods(object):
 
     def isupper(self):
         '''
-        Does the value contain only uppercase characters?
+        Does the value contains only uppercase characters.
 
         See Also
         --------
@@ -8343,7 +8341,7 @@ class CharacterColumnMethods(object):
 
     def istitle(self):
         '''
-        Is the value equivalent to the title representation?
+        Indicates whether the value is equivalent to the title representation.
 
         See Also
         --------
@@ -8358,7 +8356,7 @@ class CharacterColumnMethods(object):
 
     def isnumeric(self):
         '''
-        Does the value contain a numeric representation?
+        Indicates whether the value contains a numeric representation.
 
         See Also
         --------
@@ -8373,7 +8371,7 @@ class CharacterColumnMethods(object):
 
     def isdecimal(self):
         '''
-        Does the value contain a decimal representation?
+        Indicates whether the value contains a decimal representation.
 
         See Also
         --------
@@ -9132,9 +9130,9 @@ class CASColumn(CASTable):
         axis : int, optional
             Not implemented.
         ascending : boolean, optional
-            Should the sort order be ascending?
+            If True, the order sort is ascending. If False, order sort is descending.
         inplace : boolean, optional
-            Should the :class:`CASColumn` be modified in place?
+            If True, the :class:`CASColumn` is modified in place.
         kind : string, optional
             Not implemented.
         na_position : string, optional
@@ -9473,8 +9471,8 @@ class CASColumn(CASTable):
         dtype : string, optional
             The output data type for the computed value
         eval_values : boolean, optional
-            Should the values of CASColumn / Series values be evaluated
-            before being substituted?
+            If True, the values of CASColumn / Series will be evaluated
+            before being substituted
 
         Returns
         -------

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -1354,7 +1354,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def append_computedvars(self, *items, **kwargs):
         '''
-        Append variable names to tbl.computedvars parameter
+        Append variable names to computedvars parameter
 
         Parameters
         ----------
@@ -1390,7 +1390,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def append_groupby(self, *items, **kwargs):
         '''
-        Append variable names to tbl.groupby parameter
+        Append variable names to groupby parameter
 
         Parameters
         ----------
@@ -1424,7 +1424,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def append_computedvarsprogram(self, *items, **kwargs):
         '''
-        Append code to tbl.computedvarsprogram parameter
+        Append code to computedvarsprogram parameter
 
         Parameters
         ----------
@@ -2482,7 +2482,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def as_matrix(self, columns=None, n=None):
         '''
-        Convert the CASTable to its Numpy-array representation
+        Represent CASTable as a Numpy array 
 
         Parameters
         ----------
@@ -2650,7 +2650,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def select_dtypes(self, include=None, exclude=None, inplace=False):
         '''
-        Return a subset :class:`CASTable` including/excluding columns based on data type
+        Return a subset CASTable including/excluding columns based on data type
 
         Parameters
         ----------
@@ -2728,7 +2728,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def copy(self, deep=True, exclude=None):
         '''
-        Make a copy of the `CASTable` object
+        Make a copy of the CASTable object
 
         Parameters
         ----------
@@ -2970,7 +2970,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     @getattr_safe_property
     def iloc(self):
-        ''' Integer location based indexing for selection by position '''
+        ''' Integer-based indexer for selecting by position '''
         if isinstance(self, CASColumn):
             raise NotImplementedError('The `iloc` attribute is not implemented, '
                                       'but the attribute is reserved.')
@@ -3028,7 +3028,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def iteritems(self):
         '''
-        Iterate over column names and :class:`CASColumn` objects
+        Iterate over column names and CASColumn objects
 
         Yields
         ------
@@ -3162,7 +3162,7 @@ class CASTable(ParamManager, ActionParamManager):
         return out.at[out.index.values[0], col]
 
     def lookup(self, row_labels, col_labels):
-        ''' Retrieve values indicated by row_labels, col_labels positions '''
+        ''' Retrieve values indicated by `row_labels`, `col_labels` positions '''
         data = []
         for row, col in zip(row_labels, col_labels):
             data.append(self.get_value(row, col))
@@ -3229,7 +3229,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def datastep(self, code, casout=None, *args, **kwargs):
         '''
-        Execute Data step code against the CAS table
+        Execute Data step code against the table
 
         Parameters
         ----------
@@ -3506,7 +3506,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def all(self, axis=None, bool_only=None, skipna=True, level=None, **kwargs):
         '''
-        Return whether all elements in the column are True
+        Return True for each column with only True elements
 
         Parameters
         ----------
@@ -3515,7 +3515,7 @@ class CASTable(ParamManager, ActionParamManager):
         bool_only : bool, optional
             Not supported.
         skipna : bool, optional
-            Should missing values be skipped?  If False, and the entire
+            When set to True, skips missing values. When False and the entire
             column is missing, the result will also be a missing.
         level : int, optional
             Not supported.
@@ -3555,7 +3555,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def any(self, axis=None, bool_only=None, skipna=True, level=None, **kwargs):
         '''
-        Return whether any elements in the column are True
+        Return True for each column with at least one True element
 
         Parameters
         ----------
@@ -3564,7 +3564,7 @@ class CASTable(ParamManager, ActionParamManager):
         bool_only : bool, optional
             Not supported.
         skipna : bool, optional
-            Should missing values be included?  If not, and the entire
+            When set to True, skips missing values. When False and the entire
             column is missing, the result will also be a missing.
         level : int, optional
             Not supported.
@@ -5700,7 +5700,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def drop(self, labels, axis=0, level=None, inplace=False, errors='raise'):
         '''
-        Return a new :class:`CASTable` object with the specified columns removed
+        Return a new CASTable object with the specified columns removed
 
         Parameters
         ----------
@@ -5821,7 +5821,7 @@ class CASTable(ParamManager, ActionParamManager):
     def sample(self, n=None, frac=None, replace=False, weights=None,
                random_state=None, axis=None, stratify_by=None, **kwargs):
         '''
-        Returns a random sample of the CAS table rows
+        Returns a random sample of the table rows
 
         Parameters
         ----------
@@ -6310,7 +6310,7 @@ class CASTable(ParamManager, ActionParamManager):
     def sort_values(self, by, axis=0, ascending=True, inplace=False,
                     kind='quicksort', na_position='last'):
         '''
-        Specify sort parameters for data in a CAS table
+        Specify sort parameters for data in a CASTable
 
         Parameters
         ----------
@@ -6319,7 +6319,7 @@ class CASTable(ParamManager, ActionParamManager):
         axis : int, optional
             Not implemented.
         ascending : boolean or list-of-booleans, optional
-            Sort ascending or descending.  Specify a list of booleanss
+            Sort ascending or descending.  Specify a list of booleans
             if sort orders are not all one type.
         inplace : boolean, optional
             If True, the sort order is embedded into the CASTable
@@ -6738,7 +6738,7 @@ class CASTable(ParamManager, ActionParamManager):
     @getattr_safe_property
     def plot(self):
         '''
-        Make plots of the data in the CAS table
+        Plot the data in the table
 
         This method requires all of the data in the CAS table to be
         fetched to the **client side**.  The data is then plotted using
@@ -6960,7 +6960,7 @@ class CASTable(ParamManager, ActionParamManager):
     def info(self, verbose=None, buf=None, max_cols=None,
              memory_usage=None, null_counts=None):
         '''
-        Print summary of :class:`CASTable` information
+        Print summary of CASTable information
 
         Parameters
         ----------
@@ -7028,7 +7028,7 @@ class CASTable(ParamManager, ActionParamManager):
     def to_frame(self, sample_pct=None, sample_seed=None, sample=False,
                  stratify_by=None, **kwargs):
         '''
-        Retrieve entire table as a :class:`SASDataFrame`
+        Retrieve entire table as a SASDataFrame
 
         Parameters
         ----------
@@ -7080,7 +7080,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_xarray(self, *args, **kwargs):
         '''
-        Return an :func:`numpy.xarray` from the CAS table
+        Represent table data as a numpy.xarray
 
         This method creates an object on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7103,7 +7103,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_pickle(self, *args, **kwargs):
         '''
-        Pickle (serialize) the CAS table data
+        Pickle (serialize) the table data
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7126,7 +7126,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_csv(self, *args, **kwargs):
         '''
-        Write CAS table data to comma separated values (CSV)
+        Write table data to comma-separated values (CSV)
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7149,7 +7149,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_hdf(self, *args, **kwargs):
         '''
-        Write CAS table data to HDF
+        Write table data to HDF
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7172,7 +7172,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_sql(self, *args, **kwargs):
         '''
-        Write CAS table records to SQL database
+        Write table records to SQL database
 
         This method depends on data on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7195,7 +7195,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_dict(self, *args, **kwargs):
         '''
-        Convert CAS table data to a Python dictionary
+        Convert table data to a Python dictionary
 
         This method writes an object on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7222,7 +7222,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_excel(self, *args, **kwargs):
         '''
-        Write CAS table data to an Excel spreadsheet
+        Write table data to an Excel spreadsheet
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7245,7 +7245,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_json(self, *args, **kwargs):
         '''
-        Convert the CAS table data to a JSON string
+        Convert the table data to a JSON string
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7268,7 +7268,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_html(self, *args, **kwargs):
         '''
-        Render the CAS table data to an HTML table
+        Render the table data to an HTML table
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7291,7 +7291,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_latex(self, *args, **kwargs):
         '''
-        Render the CAS table data to a LaTeX tabular environment
+        Render the table data to a LaTeX tabular environment
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7314,7 +7314,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_stata(self, *args, **kwargs):
         '''
-        Write CAS table data to Stata file
+        Write table data to Stata file
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7337,7 +7337,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_msgpack(self, *args, **kwargs):
         '''
-        Write CAS table data to msgpack object
+        Write table data to msgpack object
 
         This method writes a file on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7360,7 +7360,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_gbq(self, *args, **kwargs):
         '''
-        Write CAS table data to a Google BigQuery table
+        Write table data to a Google BigQuery table
 
         This method depends on data on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7383,7 +7383,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_records(self, *args, **kwargs):
         '''
-        Convert CAS table data to record array
+        Convert table data to record array
 
         This method writes objects on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7410,7 +7410,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_sparse(self, *args, **kwargs):
         '''
-        Convert CAS table data to SparseDataFrame
+        Convert table data to SparseDataFrame
 
         This method writes an object on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7437,7 +7437,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_dense(self, *args, **kwargs):
         '''
-        Return dense representation of CAS table data
+        Return dense representation of table data
 
         This method writes an object on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7464,7 +7464,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_string(self, *args, **kwargs):
         '''
-        Render the CAS table to a console-friendly tabular output
+        Render the table to a console-friendly tabular output
 
         This method writes a string on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7491,7 +7491,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def to_clipboard(self, *args, **kwargs):
         '''
-        Write the CAS table data to the clipboard
+        Write the table data to the clipboard
 
         This method writes the clipboard on the **client side**.  This means
         that **all of the data in the table must all be fetched**.
@@ -7742,7 +7742,7 @@ class CASTable(ParamManager, ActionParamManager):
         return out
 
     def has_groupby_vars(self):
-        ''' Does the table have By group variables configured? '''
+        ''' Return True if the table has By group variables configured '''
         return self.has_param('groupby') and self.get_param('groupby')
 
 
@@ -9202,7 +9202,7 @@ class CASColumn(CASTable):
                               bygroup_as_index=bygroup_as_index)[self.name]
 
     def nth(self, n, dropna=False, bygroup_as_index=True, casout=None):
-        ''' Return the nth row '''
+        ''' Return the `n`th row '''
         if self._use_casout_for_stat(casout):
             return self._get_casout_slice(n, columns=True, ascending=True,
                                           casout=casout, start=n)

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -3505,7 +3505,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def all(self, axis=None, bool_only=None, skipna=True, level=None, **kwargs):
         '''
-        Return True for each column with only elements that evaluate to True
+        Return True for each column with only elements that evaluate to true
 
         Parameters
         ----------
@@ -3554,7 +3554,7 @@ class CASTable(ParamManager, ActionParamManager):
 
     def any(self, axis=None, bool_only=None, skipna=True, level=None, **kwargs):
         '''
-        Return True for each column with at least one True element
+        Return True for each column with at least one true element
 
         Parameters
         ----------
@@ -9604,7 +9604,7 @@ class CASColumn(CASTable):
         return col._numrows == numrows
 
     def any(self, axis=None, bool_only=None, skipna=None, level=None, **kwargs):
-        ''' Return True for each column with one or more element treated as True '''
+        ''' Return True for each column with one or more element treated as true '''
         col = self.copy()
         if self._is_character():
             col.append_where('lengthn(%s) ^= 0' % _nlit(col.name))

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -9604,7 +9604,7 @@ class CASColumn(CASTable):
         return col._numrows == numrows
 
     def any(self, axis=None, bool_only=None, skipna=None, level=None, **kwargs):
-        ''' Return whether any elements are True '''
+        ''' Return True for each column with one or more element treated as True '''
         col = self.copy()
         if self._is_character():
             col.append_where('lengthn(%s) ^= 0' % _nlit(col.name))

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -126,7 +126,7 @@ def _get_unique(seq, lowercase=False):
     Parameters
     ----------
     lowercase : boolean
-        If true, compare elements in a case-insensitive way
+        If True, compare elements in a case-insensitive way
 
     Returns
     -------

--- a/swat/cas/utils/params.py
+++ b/swat/cas/utils/params.py
@@ -208,14 +208,14 @@ class ParamManager(object):
 
     def set_params(self, *args, **kwargs):
         '''
-        Set paramaters according to key/value pairs
+        Set paramaters according to key-value pairs
 
         Parameters
         ----------
         *args : any, optional
-           Key / value pairs specified as sequential arguments (not in tuples).
+           Key-value pairs specified as sequential arguments (not in tuples).
         **kwargs : any, optional
-           Arbitrary keyword arguments.  These key/value pairs of
+           Arbitrary keyword arguments.  These key-value pairs of
            parameters added to the CAS action's set of parameters.
 
         Returns
@@ -293,7 +293,7 @@ class ParamManager(object):
 
     def has_params(self, *keys):
         '''
-        Return a boolean indicating whether or not the parameters exist
+        Return True if the specified parameters exist
 
         Parameters
         ----------


### PR DESCRIPTION
Here are some changes to CASTable docstrings. There were no changes to functional code.

None of the docstring edits are critical, but since the CASTable API is absorbed by other products like dlpy.ImageTable, I wanted to make them stylistically similar. Style is much less important than function, though. If these suggestions don't effectively communicate how swat works, I'm open to changes. 