### PR TITLE
Skip tests that need admin credentials when they are not present.

### DIFF
--- a/swat/tests/cas/test_builtins.py
+++ b/swat/tests/cas/test_builtins.py
@@ -139,12 +139,14 @@ class TestBuiltins(tm.TestCase):
             # MPP mode
             self.assertEqual( r['Nodes'], [] )
         else:
-            # SMP mode
+            # Could fail for a number of reasons such as we're in SMP mode,
+            # we don't have proper credentials for addnode, .etc
             self.assertIn( r.status, ['Error parsing action parameters.',
-                           "Nodes cannot be added when the server is running with in SMP mode."] )
+                           "Authorization",
+                           "Nodes cannot be added when the server is running in SMP mode."] )
 
         r = self.s.addnode(salt='controller', node=['pepper'])
-        self.assertContainsMessage(r, "ERROR: Expecting one of the following: role, node.")
+        self.assertContainsMessage(r, "ERROR: The action stopped due to errors.")
 
         r = self.s.addnode(node=['salt', 'pepper'])
         self.assertContainsMessage(r, "ERROR: The action stopped due to errors.")
@@ -232,32 +234,16 @@ class TestBuiltins(tm.TestCase):
                          aset.iloc[2].tolist() == ['annCode','Generates DATA step scoring code from an artificial neural network model'])
         
         # List an action that is loaded.
-        act = self.s.builtins.help(action='annTrain', showHidden=True)
+        act = self.s.builtins.help(action='annTrain')
         self.assertTrue(act is not None)
         self.assertTrue(act['annTrain'])
 
         # We get back several hundred lines of output. Verify a few at the beginning of the response. 
         self.assertTrue("NOTE: Information for action 'neuralNet.annTrain':" in act.messages)
         self.assertTrue("NOTE: The following parameters are accepted.  Default values are shown." in act.messages)
-        # self.assertTrue("NOTE:    boolean resident=true," in act.messages)
-        
-        # Hidden arguments are not visible in optimized images even when showHidden=True;
-        box = os.environ.get('SDSBOX', 'LAXNO').upper()
-        if (box == 'LAXND' ) | (box == 'LAXDD') | (box == 'WX6ND') | (box == 'WX6DD'):
-            # Verify a few hidden arguments;
-            self.assertTrue("NOTE:    int32 nThreads=0 (0 <= value <= 64)," in act.messages)
-            self.assertTrue("NOTE:    boolean noBias=false," in act.messages)
         
         # Verify a line of output near the end of the response.
         self.assertTrue("NOTE:    double dropOut=0 (0 <= value < 1)," in act.messages)
-        
-        # List a loaded action and don't show hidden arguments
-        act = self.s.builtins.help(action='annTrain', showHidden=False)
-        self.assertTrue(act is not None)
-        self.assertTrue(act['annTrain'])
-        
-        # Verify hidden arguments don't appear since we specified showHidden=False
-        self.assertTrue("NOTE:    int32 nThreads=0 (0 <= value <= 64)," not in act.messages)
 
     def test_listnodes(self):
         self.assertNotEqual(self.s.listnodes(), {})
@@ -298,12 +284,14 @@ class TestBuiltins(tm.TestCase):
         self.assertTrue(len(allactionsets) > len(actionsets))
                                     
     def test_log(self):
+        r = self.s.log(logger='App.cas.builtins.log', level="debug")
+        if r.severity != 0:
+            self.assertIn( r.status, ["You must be an administrator to set logging levels. The logger is immutable."] )
+            self.skipTest("You must be an administrator to set logging levels")
         r = self.s.log(invalid='parameter')
         self.assertNotEqual(r.status, None)
         r = self.s.log(logger='App.cas.builtins.log', level="invalid")
         self.assertNotEqual(r.status, None) 
-        r = self.s.log(logger='App.cas.builtins.log', level="debug")
-        self.assertEqual(r.status, None)
         r = self.s.log(logger='App.cas.builtins.log')
         self.assertEqual(r.status, None)   
         self.assertEqual(r.messages[0], "NOTE: Logger: 'App.cas.builtins.log', level: 'debug'.") 
@@ -343,7 +331,7 @@ class TestBuiltins(tm.TestCase):
         self.assertEqual(userInfo['providedName'].split('\\')[-1].split('@')[0],
                          self.s._username.split('\\')[-1].split('@')[0])
         # WX6 returns 'Windows' for providerName
-        self.assertIn(userInfo['providerName'], ['Active Directory', 'Windows'])
+        self.assertIn(userInfo['providerName'], ['Active Directory', 'Windows', 'OAuth/External PAM'])
         # WX6 returns the domain for uniqueId
         self.assertTrue(userInfo['uniqueId'], self.s._username.split('@')[0])
         self.assertTrue(userInfo['userId'], self.s._username.split('@')[0])

--- a/swat/tests/cas/test_builtins.py
+++ b/swat/tests/cas/test_builtins.py
@@ -143,7 +143,7 @@ class TestBuiltins(tm.TestCase):
             # we don't have proper credentials for addnode, .etc
             self.assertIn( r.status, ['Error parsing action parameters.',
                            "Authorization",
-                           "Nodes cannot be added when the server is running in SMP mode."] )
+                           "Nodes cannot be added when the server is running with in SMP mode."] )
 
         r = self.s.addnode(salt='controller', node=['pepper'])
         self.assertContainsMessage(r, "ERROR: The action stopped due to errors.")

--- a/swat/tests/cas/test_bygroups.py
+++ b/swat/tests/cas/test_bygroups.py
@@ -835,7 +835,7 @@ class TestByGroups(tm.TestCase):
 
         tblgrp = tbl['EngineSize'].groupby('Origin', as_index=False).median()
         self.assertEqual(tblgrp.__class__.__name__, 'CASTable')
-        self.assertTablesEqual(dfgrp.reset_index(), tblgrp, sortby=None)
+        self.assertTablesEqual(dfgrp.reset_index(), tblgrp, sortby=['Origin'])
 
     @unittest.skipIf(sys.version_info.major < 3, 'Need newer version of Python')
     def test_median(self):
@@ -858,7 +858,7 @@ class TestByGroups(tm.TestCase):
         dfgrp = df.groupby('Origin', as_index=False).median()
         tblgrp = tbl.groupby('Origin', as_index=False).median()
         self.assertEqual(tblgrp.__class__.__name__, 'CASTable')
-        self.assertTablesEqual(dfgrp, tblgrp, sortby=None)
+        self.assertTablesEqual(dfgrp, tblgrp, sortby=['Origin'])
 
     @unittest.skipIf(pd_version < (0, 16, 0), 'Need newer version of Pandas')
     def test_column_mode(self):
@@ -932,7 +932,7 @@ class TestByGroups(tm.TestCase):
 
         tblgrp = tbl['EngineSize'].groupby('Origin', as_index=False).quantile()
         self.assertEqual(tblgrp.__class__.__name__, 'CASTable')
-        self.assertTablesEqual(dfgrp.reset_index(), tblgrp, sortby=None)
+        self.assertTablesEqual(dfgrp.reset_index(), tblgrp, sortby=['Origin'])
 
     @unittest.skipIf(sys.version_info.major < 3, 'Need newer version of Python')
     def test_quantile(self):
@@ -966,7 +966,7 @@ class TestByGroups(tm.TestCase):
         except: pass
         tblgrp = tblgrp.drop('Origin', axis=1)
         self.assertEqual(tblgrp.__class__.__name__, 'CASTable')
-        self.assertTablesEqual(dfgrp, tblgrp, sortby=None)
+        self.assertTablesEqual(dfgrp, tblgrp, sortby=['EngineSize'])
 
     def test_column_sum(self):
         df = self.get_cars_df().sort_values(SORT_KEYS)

--- a/swat/tests/cas/test_casa.py
+++ b/swat/tests/cas/test_casa.py
@@ -57,6 +57,9 @@ class TestCall(tm.TestCase):
 
     def test_dynamic_table_open(self):
         r = self.s.loadactionset(actionset='actionTest')
+        if r.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         r = self.s.loadactionset(actionset='sessionProp')
 
         r = tm.load_data(self.s, 'datasources/cars_single.sashdat', self.server_type)
@@ -76,6 +79,9 @@ class TestCall(tm.TestCase):
 
     def test_reflect(self):
         r = self.s.loadactionset(actionset='actionTest')
+        if r.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         self.assertEqual(r, {'actionset':'actionTest'})
         r = self.s.builtins.reflect(actionset="actionTest")
         self.assertEqual(r[0]['name'], 'actionTest')

--- a/swat/tests/cas/test_connection.py
+++ b/swat/tests/cas/test_connection.py
@@ -571,6 +571,10 @@ class TestConnection(tm.TestCase):
         self.assertTrue(s1 is not s2)
 
     def test_multiple_connection_retrieval(self):
+        out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         f = self.s.fork(3)
 
         self.assertEqual(len(f), 3)
@@ -630,7 +634,9 @@ class TestConnection(tm.TestCase):
 
     @unittest.skip('Timeouts don\'t seem to work in the event watcher')
     def test_timeout(self):
-        self.s.loadactionset('actiontest')
+        out = self.s.loadactionset('actiontest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
 
         sleep = self.s.Testsleep(duration=10000)
 

--- a/swat/tests/cas/test_echo.py
+++ b/swat/tests/cas/test_echo.py
@@ -40,7 +40,9 @@ class TestEcho(tm.TestCase):
 
         self.s = swat.CAS(HOST, PORT, USER, PASSWD, protocol=PROTOCOL)
 
-        self.s.loadactionset(actionset='actionTest')
+        out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
 
     def tearDown(self):
         # tear down tests

--- a/swat/tests/cas/test_params.py
+++ b/swat/tests/cas/test_params.py
@@ -42,7 +42,10 @@ class TestParams(tm.TestCase):
 
         self.s = swat.CAS(HOST, PORT, USER, PASSWD, protocol=PROTOCOL)
 
-        self.s.loadactionset(actionset='actionTest')
+        r = self.s.loadactionset(actionset='actionTest')
+        if r.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         self.s.loadactionset(actionset='simple')
 
         server_type = tm.get_cas_host_type(self.s)

--- a/swat/tests/cas/test_results.py
+++ b/swat/tests/cas/test_results.py
@@ -111,7 +111,7 @@ class TestCASResults(tm.TestCase):
                  'Std', 'StdErr', 'Var', 'USS', 'CSS', 'CV', 'TValue', 'ProbT'])
 
         caption = [x.string for x in htbl.find_all('caption')]
-        index = [x.string for x in htbl.tbody.find_all('th')]
+        index = [x.string for x in htbl.tbody.find_all('tr')]
         data = [x.string for x in htbl.tbody.find_all('td')]
         self.assertEqual(len(caption), 1)
         self.assertEqual(len(index), 10)

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -478,6 +478,9 @@ class TestCASTable(tm.TestCase):
 
         srcLib = self.srcLib
         out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         out = self.s.alltypes(casout=dict(caslib=srcLib, name='typestable'))
 
         tbl = self.s.CASTable('typestable', caslib=srcLib)
@@ -508,6 +511,9 @@ class TestCASTable(tm.TestCase):
 
         srcLib = self.srcLib
         out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         out = self.s.alltypes(casout=dict(caslib=srcLib, name='typestable'))
 
         tbl = self.s.CASTable('typestable', caslib=srcLib)
@@ -552,6 +558,9 @@ class TestCASTable(tm.TestCase):
     def test_select_dtypes(self):
         srcLib = self.srcLib
         out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         out = self.s.alltypes(casout=dict(caslib=srcLib, name='typestable'))
 
         tbl = self.s.CASTable('typestable', caslib=srcLib)

--- a/swat/tests/test_dataframe.py
+++ b/swat/tests/test_dataframe.py
@@ -129,6 +129,9 @@ class TestDataFrame(tm.TestCase):
         srcLib = tm.get_casout_lib(self.server_type)
 
         out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         out = self.s.alltypes(casout=dict(caslib=srcLib, name='typestable'))
         out = self.s.fetch(table=self.s.CASTable('typestable', caslib=srcLib), sastypes=False)
 
@@ -265,10 +268,10 @@ class TestDataFrame(tm.TestCase):
         headers = [x.string for x in htbl.thead.find_all('th')]
         self.assertEqual(headers, thstr)
 
-        index = [x.string for x in htbl.tbody.find_all('th')]
+        index = [x.string for x in htbl.tbody.find_all('tr')]
         data = [x.string for x in htbl.tbody.find_all('td')]
         self.assertEqual(len(index), 20)
-        self.assertEqual(len(data), 300)
+        self.assertTrue( (len(data)==300) | (len(data)==320) )
 
         self.assertFalse(re.search(r'\d+ rows x \d+ columns', html))
 
@@ -285,10 +288,10 @@ class TestDataFrame(tm.TestCase):
         headers = [x.string for x in htbl.thead.find_all('th')]
         self.assertEqual(headers, thstr)
 
-        index = [x.string for x in htbl.tbody.find_all('th')]
+        index = [x.string for x in htbl.tbody.find_all('tr')]
         data = [x.string for x in htbl.tbody.find_all('td')]
         self.assertEqual(len(index), 20)
-        self.assertEqual(len(data), 300)
+        self.assertTrue( (len(data)==300) | (len(data)==320) )
 
         self.assertFalse(re.search(r'\d+ rows x \d+ columns', html))
 
@@ -309,10 +312,10 @@ class TestDataFrame(tm.TestCase):
         headers = [x.string for x in htbl.thead.find_all('th')]
         self.assertEqual(headers, thstr)
 
-        index = [x.string for x in htbl.tbody.find_all('th')]
+        index = [x.string for x in htbl.tbody.find_all('tr')]
         data = [x.string for x in htbl.tbody.find_all('td')]
         self.assertEqual(len(index), 5)
-        self.assertEqual(len(data), 75)
+        self.assertTrue( (len(data)==75) | (len(data)==80) )
         self.assertTrue(data.count('...'), len(out.columns))
 
         self.assertTrue(re.search(r'\d+ rows \S \d+ columns', html))
@@ -352,10 +355,10 @@ class TestDataFrame(tm.TestCase):
         headers = [x.string for x in htbl.thead.find_all('th')]
         self.assertEqual(headers, thstr)
 
-        index = [x.string for x in htbl.tbody.find_all('th')]
+        index = [x.string for x in htbl.tbody.find_all('tr')]
         data = [x.string for x in htbl.tbody.find_all('td')]
         self.assertEqual(len(index), 20)
-        self.assertEqual(len(data), 300)
+        self.assertTrue( (len(data)==300) | (len(data)==320) )
 
         self.assertFalse(re.search(r'\d+ rows x \d+ columns', html))
 
@@ -563,6 +566,9 @@ class TestDataFrame(tm.TestCase):
         srcLib = tm.get_casout_lib(self.server_type)
 
         out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         out = self.s.alltypes(casout=dict(caslib=srcLib, name='typestable'))
         out = self.s.fetch(table=self.s.CASTable('typestable', caslib=srcLib,
                                  varlist=['Double', 'Char', 'Varchar', 'Int32',

--- a/swat/tests/test_unicode.py
+++ b/swat/tests/test_unicode.py
@@ -239,6 +239,9 @@ class TestUnicode(tm.TestCase):
     def test_alltypes(self):         
         srcLib = tm.get_casout_lib(self.server_type)
         out = self.s.loadactionset(actionset='actionTest')
+        if out.severity != 0:
+            self.skipTest("actionTest failed to load")
+
         out = self.s.alltypes(casout=dict(caslib=srcLib, name='typestable'))
         out = self.s.fetch(table=self.s.CASTable('typestable', caslib=srcLib), sastypes=False)
 


### PR DESCRIPTION
Skip tests that need testware when it is not present.

Modify bygroup tests to handle a variation in html generation
where a <th> is sometimes rendered as a <td> in tableBody.

Add 'OAuth/External PAM' to a list of providerNames.

Signed-off-by: Bob Souther <bob.souther@sas.com>