### PR TITLE
Close connection on aborted session.

### DIFF
--- a/swat/cas/connection.py
+++ b/swat/cas/connection.py
@@ -55,6 +55,7 @@ from .utils.misc import super_dir, any_file_exists
 # pylint: disable=W0212
 
 RETRY_ACTION_CODE = 0x280034
+SESSION_ABORTED_CODE = 0x2D51AC
 
 
 def _option_handler(key, value):
@@ -1753,6 +1754,10 @@ class CAS(object):
 
                 if response.disposition.status_code == RETRY_ACTION_CODE:
                     raise SWATCASActionRetry(response.disposition.status)
+                elif response.disposition.status_code == SESSION_ABORTED_CODE:
+                    # Any new requests sent to the session will never return, so just close the connection now
+                    self.close()
+                    raise SWATCASActionError(response.disposition.status, response, conn)
 
                 if responsefunc is not None:
                     responsedata = responsefunc(response, conn, responsedata)

--- a/swat/tests/cas/test_connection.py
+++ b/swat/tests/cas/test_connection.py
@@ -826,6 +826,19 @@ class TestConnection(tm.TestCase):
         self.assertFalse(self.s.has_actionset('unknownActionSet'))
         self.assertFalse(self.s.has_actionset('unknownactionset'))
 
+    def test_session_aborted(self):
+        from unittest import mock
+        from swat import SWATCASActionError
+        from swat.utils.testingmocks import mock_getone_session_aborted
+
+        # Mock swat.cas.connection.getone to return a response with the session aborted error
+        # Mock CAS.close so we can verify it gets called
+        with mock.patch('swat.cas.connection.getone', new=mock_getone_session_aborted), \
+             mock.patch.object(swat.CAS, 'close', autospec=True) as mock_close:
+            with self.assertRaisesRegex(SWATCASActionError, swat.utils.testingmocks.SESSION_ABORTED_MESSAGE):
+                self.s.about()
+            mock_close.assert_called_with(self.s)
+
 
 if __name__ == '__main__':
    import xmlrunner

--- a/swat/utils/testingmocks.py
+++ b/swat/utils/testingmocks.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+'''
+Mocks for testing
+
+'''
+
+from unittest import mock
+
+import swat
+
+SESSION_ABORTED_MESSAGE = "The Session is no longer active due to an unhandled exception."
+
+
+def mock_getone_session_aborted(connection, datamsghandler=None):
+    '''
+    Mock getting a single "session aborted" response from a connection
+
+    Parameters
+    ----------
+    connection : :class:`CAS` object
+        The connection/CASAction to get the mock response from.
+    datamsghandler : :class:`CASDataMsgHandler` object, optional
+        The object to use for data messages from the server. This is not used in the mock.
+
+    See Also
+    --------
+    :meth:`swat.cas.connection.getone`
+
+    Returns
+    -------
+    :class:`CASResponse` object
+
+    '''
+
+    # Mock the CAS Response object
+    with mock.patch('swat.cas.response.CASResponse', autospec=True):
+        response = swat.cas.response.CASResponse(None)
+        response.disposition.status = SESSION_ABORTED_MESSAGE
+        response.disposition.status_code = swat.cas.connection.SESSION_ABORTED_CODE
+        return response, connection
+


### PR DESCRIPTION
When the session returns a "session aborted" response, any future
requests to that session will hang. This commit addresses that issue by
closing the connection when that status code is detected, and raising an
exception to notify the user.

Signed-off-by: Avy Harvey <avy.harvey@sas.com>