### PR TITLE
Remove elasticsearch actionset because it doesn't appear in

### DIFF
--- a/swat/tests/cas/test_builtins.py
+++ b/swat/tests/cas/test_builtins.py
@@ -331,7 +331,7 @@ class TestBuiltins(tm.TestCase):
         self.assertEqual(userInfo['providedName'].split('\\')[-1].split('@')[0],
                          self.s._username.split('\\')[-1].split('@')[0])
         # WX6 returns 'Windows' for providerName
-        self.assertIn(userInfo['providerName'], ['Active Directory', 'Windows', 'OAuth/External PAM'])
+        self.assertIn(userInfo['providerName'], ['Active Directory', 'Windows', 'OAuth/External PAM', 'External PAM'])
         # WX6 returns the domain for uniqueId
         self.assertTrue(userInfo['uniqueId'], self.s._username.split('@')[0])
         self.assertTrue(userInfo['userId'], self.s._username.split('@')[0])

--- a/swat/tests/cas/test_connection.py
+++ b/swat/tests/cas/test_connection.py
@@ -141,19 +141,19 @@ class TestConnection(tm.TestCase):
 
         self.assertTrue('builtins.loadactionset' in dirout)
         self.assertTrue('table.loadtable' in dirout)
-        self.assertTrue('elasticsearch.index' not in dirout)
-        self.assertTrue('sandindex' not in dirout)
-        self.assertTrue('elasticsearch.sandindex' not in dirout)
+        self.assertTrue('autotune.tuneall' not in dirout)
+        self.assertTrue('tunesvm' not in dirout)
+        self.assertTrue('autotune.tunesvm' not in dirout)
 
-        self.s.loadactionset('elasticsearch')
+        self.s.loadactionset('autotune')
 
         dirout = self.s.__dir__()
 
         self.assertTrue('builtins.loadactionset' in dirout)
         self.assertTrue('table.loadtable' in dirout)
-        self.assertTrue('elasticsearch.index' in dirout)
-        self.assertTrue('sandindex' in dirout)
-        self.assertTrue('elasticsearch.sandindex' in dirout)
+        self.assertTrue('autotune.tuneall' in dirout)
+        self.assertTrue('tunesvm' in dirout)
+        self.assertTrue('autotune.tunesvm' in dirout)
 
     def test_str(self):
         s = str(self.s)

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -178,12 +178,12 @@ class TestCASTable(tm.TestCase):
         self.assertTrue('session.timeout' in dirout)
         self.assertTrue('sessionid' in dirout)
         self.assertTrue('session.sessionid' in dirout)
-        self.assertTrue('elasticsearch' not in dirout)
-        self.assertTrue('elasticsearch.index' not in dirout)
-        self.assertTrue('sandindex' not in dirout)
-        self.assertTrue('elasticsearch.sandindex' not in dirout)
+        self.assertTrue('autotune' not in dirout)
+        self.assertTrue('autotune.tuneall' not in dirout)
+        self.assertTrue('tunesvm' not in dirout)
+        self.assertTrue('autotune.tunesvm' not in dirout)
 
-        self.s.loadactionset('elasticsearch')
+        self.s.loadactionset('autotune')
 
         dirout = self.table.__dir__()
 
@@ -191,9 +191,9 @@ class TestCASTable(tm.TestCase):
         self.assertTrue('session.timeout' in dirout)
         self.assertTrue('sessionid' in dirout)
         self.assertTrue('session.sessionid' in dirout)
-        self.assertTrue('elasticsearch.index' in dirout)
-        self.assertTrue('sandindex' in dirout)
-        self.assertTrue('elasticsearch.sandindex' in dirout)
+        self.assertTrue('autotune.tuneall' in dirout)
+        self.assertTrue('tunesvm' in dirout)
+        self.assertTrue('autotune.tunesvm' in dirout)
 
         # Whack connection
         self.table.set_connection(None)


### PR DESCRIPTION
shipped products anymore.

Add 'External PAM' to a list of providerNames.

Signed-off-by: Bob Souther <bob.souther@sas.com>