### PR TITLE
When running in kubernetes, the addNode action is prohibited.

### DIFF
--- a/swat/tests/cas/test_builtins.py
+++ b/swat/tests/cas/test_builtins.py
@@ -134,7 +134,11 @@ class TestBuiltins(tm.TestCase):
         #self.assertEqual( r.debug, None )        
 
     def test_addnode(self):
-        r = self.s.addnode()
+        try:
+            r = self.s.addnode()
+        except TypeError:
+            tm.TestCase.skipTest(self, 'addnode action is not available')
+
         if r.severity == 0:
             # MPP mode
             self.assertEqual( r['Nodes'], [] )


### PR DESCRIPTION
In test_addnode when calling addnode and the action can't be invoked,
catch a TypeError and skip the test. Otherwise continue the test.

Signed-off-by: Bob Souther <bob.souther@sas.com>