### PR TITLE
Added implementation of CASTable.rename

### DIFF
--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5976,6 +5976,7 @@ class CASTable(ParamManager, ActionParamManager):
         -------
         :class:`CASTable`
         '''
+
         #Columns is a dict:
         alterTable = []
         if isinstance(columns, dict):

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5980,15 +5980,15 @@ class CASTable(ParamManager, ActionParamManager):
         #Columns is a dict:
         alterTable = []
         if isinstance(columns, dict):
-            #Errors to be raised -> check all keys upfront
-            if errors == 'raise':
-                for key in columns.keys():
-                    if key not in self.columns:
-                        raise KeyError("Column is not found in CASTable: " + key)
-
             #Convert Pandas-style dict to CAS-style list of dicts
             for oldName, newName in columns.items():
-                alterTable.append({'name': oldName, 'rename': newName})
+                if oldName in self.columns:
+                    alterTable.append({'name': oldName, 'rename': newName})
+                #If we encounter a key that doesn't exist as column
+                #and we are raising errors, we do that here
+                elif errors == 'raise':
+                    raise KeyError("Column is not found in CASTable: " + oldName)
+
         #Columns is a function:
         elif callable(columns):
             #Iterate through all table columns and apply function

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5959,7 +5959,7 @@ class CASTable(ParamManager, ActionParamManager):
 #   def reindex_like(self, *args, **kwargs):
 #       raise NotImplementedError
 
-    def rename(self, columns, errors='ignore', inplace=True, **kwargs):
+    def rename(self, columns, errors='ignore', **kwargs):
         '''
         Rename columns of the CASTable.
 
@@ -5976,18 +5976,12 @@ class CASTable(ParamManager, ActionParamManager):
         -------
         :class:`CASTable`
         '''
-        #If we are working in place, our working table is the table itself
-        table = self
-        #If not, we need to make a copy
-        if not inplace:
-            table = copy.deepcopy(self)
-
         #Columns is a dict:
         alterTable = []
         if isinstance(columns, dict):
             #Convert Pandas-style dict to CAS-style list of dicts
             for oldName, newName in columns.items():
-                if oldName in table.columns:
+                if oldName in self.columns:
                     alterTable.append({'name': oldName, 'rename': newName})
                 #If we encounter a key that doesn't exist as column
                 #and we are raising errors, we do that here
@@ -5997,14 +5991,14 @@ class CASTable(ParamManager, ActionParamManager):
         #Columns is a function:
         elif callable(columns):
             #Iterate through all table columns and apply function
-            for col in table.columns:
+            for col in self.columns:
                 alterTable.append({'name': col, 'rename': columns(col)})
         else:
             raise TypeError("Columns must be a dict or function")
 
         #Use list of dicts to rename using alterTable action
-        table._retrieve('alterTable', columns=alterTable)
-        return table
+        self._retrieve('alterTable', columns=alterTable)
+        return self
 
     def reset_index(self, level=None, drop=False, inplace=False,
                     col_level=0, col_fill='', **kwargs):

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5998,7 +5998,7 @@ class CASTable(ParamManager, ActionParamManager):
             raise TypeError("Columns must be a dict or function")
 
         #Use list of dicts to rename using alterTable action
-        self._invoke('alterTable', columns=alterTable)
+        self._retrieve('alterTable', columns=alterTable)
         return self
 
     def reset_index(self, level=None, drop=False, inplace=False,

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5976,13 +5976,18 @@ class CASTable(ParamManager, ActionParamManager):
         -------
         :class:`CASTable`
         '''
+        #If we are working in place, our working table is the table itself
+        table = self
+        #If not, we need to make a copy
+        if not inplace:
+            table = copy.deepcopy(self)
 
         #Columns is a dict:
         alterTable = []
         if isinstance(columns, dict):
             #Convert Pandas-style dict to CAS-style list of dicts
             for oldName, newName in columns.items():
-                if oldName in self.columns:
+                if oldName in table.columns:
                     alterTable.append({'name': oldName, 'rename': newName})
                 #If we encounter a key that doesn't exist as column
                 #and we are raising errors, we do that here
@@ -5992,14 +5997,14 @@ class CASTable(ParamManager, ActionParamManager):
         #Columns is a function:
         elif callable(columns):
             #Iterate through all table columns and apply function
-            for col in self.columns:
+            for col in table.columns:
                 alterTable.append({'name': col, 'rename': columns(col)})
         else:
             raise TypeError("Columns must be a dict or function")
 
         #Use list of dicts to rename using alterTable action
-        self._retrieve('alterTable', columns=alterTable)
-        return self
+        table._retrieve('alterTable', columns=alterTable)
+        return table
 
     def reset_index(self, level=None, drop=False, inplace=False,
                     col_level=0, col_fill='', **kwargs):

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5998,7 +5998,8 @@ class CASTable(ParamManager, ActionParamManager):
             raise TypeError("Columns must be a dict or function")
 
         #Use list of dicts to rename using alterTable action
-        return self._retrieve('alterTable', columns=alterTable)
+        self._invoke('alterTable', columns=alterTable)
+        return self
 
     def reset_index(self, level=None, drop=False, inplace=False,
                     col_level=0, col_fill='', **kwargs):

--- a/swat/cas/table.py
+++ b/swat/cas/table.py
@@ -5977,27 +5977,27 @@ class CASTable(ParamManager, ActionParamManager):
         :class:`CASTable`
         '''
 
-        #Columns is a dict:
+        # Columns is a dict:
         alterTable = []
         if isinstance(columns, dict):
-            #Convert Pandas-style dict to CAS-style list of dicts
+            # Convert Pandas-style dict to CAS-style list of dicts
             for oldName, newName in columns.items():
                 if oldName in self.columns:
                     alterTable.append({'name': oldName, 'rename': newName})
-                #If we encounter a key that doesn't exist as column
-                #and we are raising errors, we do that here
+                # If we encounter a key that doesn't exist as column
+                # and we are raising errors, we do that here
                 elif errors == 'raise':
                     raise KeyError("Column is not found in CASTable: " + oldName)
 
-        #Columns is a function:
+        # Columns is a function:
         elif callable(columns):
-            #Iterate through all table columns and apply function
+            # Iterate through all table columns and apply function
             for col in self.columns:
                 alterTable.append({'name': col, 'rename': columns(col)})
         else:
             raise TypeError("Columns must be a dict or function")
 
-        #Use list of dicts to rename using alterTable action
+        # Use list of dicts to rename using alterTable action
         self._retrieve('alterTable', columns=alterTable)
         return self
 

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -5175,6 +5175,7 @@ class TestCASTable(tm.TestCase):
         self.assertTablesEqual(colinfo[['Two', 'Model', 'One', 'MSRP']], pcolinfo)
 
     def test_rename(self):
+        # Pull in CASTable and Pandas Dataframe
         tbl = self.table
         df = self.get_cars_df()
 

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -5176,30 +5176,38 @@ class TestCASTable(tm.TestCase):
 
     def test_rename(self):
         tbl = self.table
+        df = self.get_cars_df()
 
         # Rename by name:
         makeCol = tbl['Make']
         self.assertTrue(any(col in 'Make' for col in list(tbl.columns)))
         tbl.rename({'Make': 'Manufacturer'})
+        df.rename(columns={'Make': 'Manufacturer'}, inplace=True)
         # No column named "Make" and a column named "Manufacturer"
         self.assertFalse(any(col in 'Make' for col in list(tbl.columns)))
         self.assertTrue(any(col in 'Manufacturer' for col in list(tbl.columns)))
         # Shouldn't be a "new" column, just 'Make' renamed
         self.assertEqual(makeCol, tbl['Manufacturer'])
+        # Shoud be same as pandas
+        self.assertTablesEqual(tbl, df)
 
         # Rename by function:
         # Column Manufacturer -> Manufacturer_0
         tbl.rename(lambda col: col + "_0")
+        df.rename(columns=lambda col: col + "_0", inplace=True)
         for col in list(tbl.columns):
             # Last two characters should be _0 for each col
             self.assertEqual(col[-2:], "_0")
+        self.assertTablesEqual(tbl, df)
 
         # Rename by name for col that doesn't exist
         # errors='ignore'
         originalCols = list(copy.deepcopy(tbl.columns))
         tbl.rename({'nope': 'nuh uh'})
+        df.rename(columns={'nope': 'nuh uh'}, inplace=True)
         self.assertFalse(any(col in 'nope' for col in list(tbl.columns)))
         self.assertListEqual(originalCols, list(tbl.columns))
+        self.assertTablesEqual(tbl, df)
 
         # Rename by name for col that doesn't exist
         # errors='raise'

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -5174,6 +5174,38 @@ class TestCASTable(tm.TestCase):
         pcolinfo = pcolinfo.drop('ID', errors='ignore').drop('Label', errors='ignore')
         self.assertTablesEqual(colinfo[['Two', 'Model', 'One', 'MSRP']], pcolinfo)
 
+    def test_rename(self):
+        tbl = self.table
+
+        # Rename by name:
+        makeCol = tbl['Make']
+        self.assertTrue(any(col in 'Make' for col in list(tbl.columns)))
+        tbl.rename({'Make':'Manufacturer'})
+        # No column named "Make" and a column named "Manufacturer"
+        self.assertFalse(any(col in 'Make' for col in list(tbl.columns)))
+        self.assertTrue(any(col in 'Manufacturer' for col in list(tbl.columns)))
+        # Shouldn't be a "new" column, just 'Make' renamed
+        self.assertEqual(makeCol, tbl['Manufacturer'])
+
+        # Rename by function:
+        # Column Manufacturer -> Manufacturer_0
+        tbl.rename(lambda col : col + "_0")
+        for col in list(tbl.columns):
+            # Last two characters should be _0 for each col
+            self.assertEqual(col[-2:], "_0")
+
+        # Rename by name for col that doesn't exist
+        # errors='ignore'
+        originalCols = list(copy.deepcopy(tbl.columns))
+        tbl.rename({'nope':'nuh uh'})
+        self.assertFalse(any(col in 'nope' for col in list(tbl.columns)))
+        self.assertListEqual(originalCols, list(tbl.columns))
+
+        # Rename by name for col that doesn't exist
+        # errors='raise'
+        with self.assertRaises(KeyError):
+            tbl.rename(tbl.rename({'nope':'nuh uh'}, errors='raise'))
+
     def test_reset_index(self):
         tbl = self.table
 

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -5180,7 +5180,7 @@ class TestCASTable(tm.TestCase):
         # Rename by name:
         makeCol = tbl['Make']
         self.assertTrue(any(col in 'Make' for col in list(tbl.columns)))
-        tbl.rename({'Make':'Manufacturer'})
+        tbl.rename({'Make': 'Manufacturer'})
         # No column named "Make" and a column named "Manufacturer"
         self.assertFalse(any(col in 'Make' for col in list(tbl.columns)))
         self.assertTrue(any(col in 'Manufacturer' for col in list(tbl.columns)))
@@ -5189,7 +5189,7 @@ class TestCASTable(tm.TestCase):
 
         # Rename by function:
         # Column Manufacturer -> Manufacturer_0
-        tbl.rename(lambda col : col + "_0")
+        tbl.rename(lambda col: col + "_0")
         for col in list(tbl.columns):
             # Last two characters should be _0 for each col
             self.assertEqual(col[-2:], "_0")
@@ -5197,14 +5197,14 @@ class TestCASTable(tm.TestCase):
         # Rename by name for col that doesn't exist
         # errors='ignore'
         originalCols = list(copy.deepcopy(tbl.columns))
-        tbl.rename({'nope':'nuh uh'})
+        tbl.rename({'nope': 'nuh uh'})
         self.assertFalse(any(col in 'nope' for col in list(tbl.columns)))
         self.assertListEqual(originalCols, list(tbl.columns))
 
         # Rename by name for col that doesn't exist
         # errors='raise'
         with self.assertRaises(KeyError):
-            tbl.rename(tbl.rename({'nope':'nuh uh'}, errors='raise'))
+            tbl.rename(tbl.rename({'nope': 'nuh uh'}, errors='raise'))
 
     def test_reset_index(self):
         tbl = self.table

--- a/swat/tests/cas/test_table.py
+++ b/swat/tests/cas/test_table.py
@@ -5182,6 +5182,7 @@ class TestCASTable(tm.TestCase):
         makeCol = tbl['Make']
         self.assertTrue(any(col in 'Make' for col in list(tbl.columns)))
         tbl.rename({'Make': 'Manufacturer'})
+        # We use inplace=True as that's what CASTable.rename is doing
         df.rename(columns={'Make': 'Manufacturer'}, inplace=True)
         # No column named "Make" and a column named "Manufacturer"
         self.assertFalse(any(col in 'Make' for col in list(tbl.columns)))
@@ -5203,6 +5204,7 @@ class TestCASTable(tm.TestCase):
         # Rename by name for col that doesn't exist
         # errors='ignore'
         originalCols = list(copy.deepcopy(tbl.columns))
+        # This column doesn't exist, so it'll just ignore it
         tbl.rename({'nope': 'nuh uh'})
         df.rename(columns={'nope': 'nuh uh'}, inplace=True)
         self.assertFalse(any(col in 'nope' for col in list(tbl.columns)))
@@ -5212,6 +5214,7 @@ class TestCASTable(tm.TestCase):
         # Rename by name for col that doesn't exist
         # errors='raise'
         with self.assertRaises(KeyError):
+            # This column doesn't exist and errors='raise', it'll raise an exception
             tbl.rename(tbl.rename({'nope': 'nuh uh'}, errors='raise'))
 
     def test_reset_index(self):


### PR DESCRIPTION
Implemented and tested new CASTable.rename implementation. This new function enables SWAT users to rename the columns in their table by either providing a dictionary of mappings for some or all columns or a function to apply to all columns.