### PR TITLE
Added support for new Image DMH file extensions.

### DIFF
--- a/swat/cas/datamsghandlers.py
+++ b/swat/cas/datamsghandlers.py
@@ -1245,7 +1245,7 @@ class Image(CASDataMsgHandler):
         if isinstance(data, str):
             files = []
             extensions = ['bmp', 'dib', 'jpg', 'jpeg', 'jpe', 'jp2', 'png', 'pbm', 'pmg',
-                          'ppm', 'tif', 'tiff', 'webp', 'hdr', 'pic', 'dcm', 'dicom',
+                          'ppm', 'tif', 'tiff', 'webp', 'pic', 'dcm', 'dicom',
                           'nrrd', 'nhdr', 'raw', 'nii', 'img', 'hdr', 'mha', 'mhd',
                           'saswimg', 'sastimg']
 

--- a/swat/cas/datamsghandlers.py
+++ b/swat/cas/datamsghandlers.py
@@ -1245,7 +1245,9 @@ class Image(CASDataMsgHandler):
         if isinstance(data, str):
             files = []
             extensions = ['bmp', 'dib', 'jpg', 'jpeg', 'jpe', 'jp2', 'png', 'pbm', 'pmg',
-                          'ppm', 'tif', 'tiff', 'webp']
+                          'ppm', 'tif', 'tiff', 'webp', 'hdr', 'pic', 'dcm', 'dicom',
+                          'nrrd', 'nhdr', 'raw', 'nii', 'img', 'hdr', 'mha', 'mhd',
+                          'saswimg', 'sastimg']
 
             # Also search for uppercase file extensions if not running on a
             # case-insensitive OS (Windows).


### PR DESCRIPTION
Adds support for more file extensions when using the Image Data Message Handler. With this change, the upload of client-side biomedical images to CAS is now possible.