### PR TITLE
do not create install files for Python < 3.7

### DIFF
--- a/cicd/generate-tox-ini.py
+++ b/cicd/generate-tox-ini.py
@@ -54,6 +54,12 @@ def get_supported_versions(root):
     out = set()
     for ver in glob.glob(os.path.join(root, 'swat', 'lib', '*', '_py*swat*.*')):
         ver = re.match(r'_py(\d*)swat', os.path.basename(ver)).group(1) or '27'
+        if (ver[0] == '2'):
+            # print_err("get_supported_versions: skipping {}".format(ver))
+            continue
+        if ((int(ver[1:]) < 7) and (ver[0] == '3')):
+            # print_err("get_supported_versions: skipping {}".format(ver))
+            continue
         out.add('{}.{}'.format(ver[0], ver[1:]))
     return list(sorted(out))
 

--- a/cicd/tar2conda.py
+++ b/cicd/tar2conda.py
@@ -261,6 +261,13 @@ def main(url, args):
                 # Anaconda doesn't do narrow character builds; just use _pyswatw for 2.7
                 if m.group(2).split('.')[0] == '_pyswat':
                     continue
+
+                if ((m.group(3) == '') or (int(m.group(3)) < 37)):
+                    # Don't create wheel file for Python 2.7, 3.5, or 3.6
+                    msg = "tar2conda.main : m.group(3) {} is empty or < 37, skipping"
+                    print_err(msg.format(m.group(3)))
+                    continue
+
                 platform = m.group(1)
                 pvlist = list(m.group(3) or '27')
                 if len(pvlist) < 2:

--- a/cicd/tar2wheel.py
+++ b/cicd/tar2wheel.py
@@ -404,11 +404,19 @@ def main(url, args):
         for name in names:
             m = re.search(r'(\w+)[\\/](_py(\d*)swat(w?)\.\w+)$', name)
             if m:
+                if ((m.group(3) == '') or (int(m.group(3)) < 37)):
+                    # Don't create wheel file for Python 2.7, 3.5, or 3.6
+                    msg = "tar2wheel.main : m.group(3) {} is empty or < 37, skipping"
+                    print_err(msg.format(m.group(3)))
+                    continue
+
                 platform = m.group(1)
                 versions.append(dict(extension=m.group(2),
-                                     pyversion='cp%s' % (m.group(3) or '27'),
-                                     abi='cp%sm%s' % ((m.group(3) or '27'),
-                                                      m.group(4) and 'u' or '')))
+                                     pyversion='cp%s' % (m.group(3)),
+                                     abi='cp%sm' % (m.group(3))))
+# special handling for python 2.7, no longer needed
+#                                     abi='cp%sm%s' % ((m.group(3) or '27'),
+#                                                      m.group(4) and 'u' or '')))
                 if int(versions[-1]['pyversion'].replace('cp', '')) >= 38:
                     versions[-1]['abi'] = versions[-1]['abi'].replace('m', '')
 


### PR DESCRIPTION
do not create .whl (pypi) or .bz2 (conda) files for Python 2.7, 3.5, or 3.6.
Installation of swat on these versions of Python is still supported using the tar.gz file on github.